### PR TITLE
Fix table style rule

### DIFF
--- a/static/css/main-site.css
+++ b/static/css/main-site.css
@@ -1316,6 +1316,7 @@ table tbody tr td{
 
 table tbody tr td:last-child{
   padding: 15px 0;
+}
 
 table, tbody, tfoot, thead, tr, th, td {
   margin: 0;


### PR DESCRIPTION
Teensy tiny closing bracket was missing on this css rule, affecting some table styling