### PR TITLE
Set aria-hidden = TRUE for blog-post images

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -13,7 +13,7 @@
           <div class="listItem">
              {{ $card := (.Resources.ByType "image").GetMatch "*-sq*" }}
              {{ with $card }}
-              <a class="itemImage project" href="{{ $post.RelPermalink }}" style="background-image: url('{{ .RelPermalink }}');"></a>
+             <div class="itemImage project" aria-hidden="true" style="background-image: url('{{ .RelPermalink }}');"></div>
               {{ end }}
             <div class="itemDetails">
               <div class="itemHeader">


### PR DESCRIPTION
* Set aria-hidden for images
* Remove link from image to avoid duplication for accessibility
* Fixes #21

See also: https://github.com/tidyverse/tidyverse.org/pull/411